### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -31,7 +31,7 @@ changeBaudRate	KEYWORD2
 changeI2CAddress	KEYWORD2
 setCursor	KEYWORD2
 createChar	KEYWORD2
-setBacklightBrightness KEYWORD2
+setBacklightBrightness	KEYWORD2
 setContrast	KEYWORD2
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords